### PR TITLE
:white_check_mark: Fix DeprecationWarning: Please use assertEqual instead

### DIFF
--- a/src/tests/test_services/test_attack_service.py
+++ b/src/tests/test_services/test_attack_service.py
@@ -26,7 +26,7 @@ class TestAttackService(TestCase):
         attack = attack_service.get_attack_with_identifier_from_webservice(identifier)
 
         # THEN
-        self.assertEquals(identifier, attack.id)
+        self.assertEqual(identifier, attack.id)
 
     def test_get_pokemon_name_Pikachu(self):
         # GIVEN
@@ -37,7 +37,7 @@ class TestAttackService(TestCase):
         attack = attack_service.get_attack_with_identifier_from_webservice(identifier)
 
         # THEN
-        self.assertEquals(identifier, attack.name)
+        self.assertEqual(identifier, attack.name)
 
     def test_get_pokemon_name_not_found(self):
         # GIVEN

--- a/src/tests/test_services/test_pokemon_service.py
+++ b/src/tests/test_services/test_pokemon_service.py
@@ -27,7 +27,7 @@ class TestPokemonService(TestCase):
         pokemons = pokemon_service.get_pokemon_from_webservice(limit, 0)
 
         # THEN
-        self.assertEquals(limit, len(pokemons))
+        self.assertEqual(limit, len(pokemons))
 
     def test_get_pokemon_id_1(self):
         # GIVEN
@@ -40,7 +40,7 @@ class TestPokemonService(TestCase):
         )
 
         # THEN
-        self.assertEquals(identifier, pokemon.id)
+        self.assertEqual(identifier, pokemon.id)
 
     def test_get_pokemon_name_Pikachu(self):
         # GIVEN
@@ -53,7 +53,7 @@ class TestPokemonService(TestCase):
         )
 
         # THEN
-        self.assertEquals(identifier, pokemon.name)
+        self.assertEqual(identifier, pokemon.name)
 
     def test_get_pokemon_name_not_found(self):
         # GIVEN


### PR DESCRIPTION
Au lancement des tests, plusieurs warnings apparaissent :

> .................................\src\tests\test_services\test_attack_service.py:29: DeprecationWarning: Please use assertEqual instead.
>   self.assertEquals(identifier, attack.id)
> ........\src\tests\test_services\test_pokemon_service.py:30: DeprecationWarning: Please use assertEqual instead.
>   self.assertEquals(limit, len(pokemons))
> ....

Cette MR corrige ces warnings en appliquant la modification proposée et permet une exécution des tests sans erreur